### PR TITLE
## 0.5.0  update the dependency to support Spark 3.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ecosystem"]
+	path = ecosystem
+	url = https://github.com/tensorflow/ecosystem/

--- a/README.md
+++ b/README.md
@@ -492,10 +492,12 @@ notice here that DatasetFeatureStatisticsList is class generated based on protob
 ## Development
  This is maven project, so it usually follows the standard maven commands for build. 
 
-### Build
+### Build 
 ```
     mvn clean package
 ```
+    * this works for Apache Spark 2.4.x (branch v0.4.1), but we need additional steps for Apache Spark 3
+    * see section on Apache Spark 3
 
 ### Test
 ```
@@ -531,3 +533,38 @@ notice here that DatasetFeatureStatisticsList is class generated based on protob
  hundreds MB if you have more than one such features. The UI mearly use these to show raw data, so set 
  catHistgmLevel = Some(20) should be enough. This can significant reduce the result file size.
 
+## Apache Spark 3 support and branches
+
+note we have upgraded the code to support Apache spark 3. To do so, we created the following branches
+
+* v0.4.1 branch is used for Apache Spark 2.4.x, Scala 2.11
+
+* main branch is now used for Apache Spark 3, and Scala 2.12 
+
+  Apache Spark 3 requires scala 2.12. Facets-overview-spark depends on Spark-tensorflow-connector. 
+  At this time (2021-06-02), spark-tensorflow-connector has no release jar available at maven central repository for Scala 2.12
+  so we temporarily add git submodule to the project, so we can build Spark-tensorflow-connector locally
+
+  The details of git submodule can be found at [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules),
+  when clone the project, you need to 
+  ```
+    git clone --recurse-submodules git@github.com:gopro/facets-overview-spark.git
+  ```
+  to include tensorflow ecosystem submodule, then
+  ```
+     cd ecosystem/spark/spark-tensorflow-connector;
+     mvn clean install 
+  ```
+  once you have the jar created in local mvn repository, then you can build normally in the current project.
+
+  ```
+      cd facets-overview-spark
+      mvn clean package
+  ```
+
+  If you already have cloned the project without --recurse-submodules. 
+  You need to do git submodule init and git submodule update as described in above documentation
+  
+  
+
+ 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,26 @@
 ## change Log, latest version on top
+
+0.5.0  update the dependency to support Spark 3.0.1 
+   *   Spark 3 requires Scala 2.12, we have to few dependency upgrade as well, in particular,
+       scala-maven-plugin, scalatest, spark-tensorflow-connector and scalapb
+   *   scala-maven-plugin version 4.3.1 works, but higher version such as 4.4.x, 4.5.x do not work.
+       If you use version 4.4.x, 4.5.x, you will get error identical to the one reported in : 
+       http://5.9.10.113/66489291/project-build-with-circle-ci-is-failing
+   *   with change to scalapb to the current version, the protobuf version argument is changed. 
+       in scalapb 0.9.8 if the protobuf version is 3.8.0 then the argument is v380 and v261 for version 2.6.1
+       in scalapb 0.11.0 we need to specify v3.8.0 for version 3.8.0
+   *   spark-tensorflow-connector has no scala 2.12 releases at the moment, although the master branch does 
+       has code for scala 2.12. Instead of waiting for the official release, we temporarily build the dependency ourselves. 
+       We add git submodule of tensorflow/ecosystem, then build the dependency locally
+       ```
+           cd ecosystem/spark/spark-tensorflow-connector;
+           mvn clean install 
+       ```
+   *   change scalatest dependency to version 3.0.5. 
+       when change the scalatest to the later versions > "3.0.5", the tests will show errors like ```"object FunSuite is not a member of package org.scalatest"```  
+
+
+
 0.4.1  README and change log changes, created the branch for v.0.4.1 Apache Spark 2.4.x development
        The main branch will be upgrade to Apache Spark 3.0 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,21 +22,20 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>facets-overview-spark</groupId>
-    <version>0.4.1</version>
+    <version>0.5.0</version>
     <artifactId>facets-overview-spark</artifactId>
     <name>facets-overview-spark</name>
     <organization>
         <name>GoPro</name>
     </organization>
     <properties>
-        <dse.spark.version>2.4.3</dse.spark.version>
-        <dse.scalapb.version>0.9.8</dse.scalapb.version>
+        <dse.spark.version>3.0.1</dse.spark.version>
+        <dse.scalapb.version>0.11.0</dse.scalapb.version>
         <dse.mockito.version>1.10.19</dse.mockito.version>
-        <dse.scala.version>2.11</dse.scala.version>
-        <dse.scala.binary.version>2.11</dse.scala.binary.version>
+        <dse.scala.version>2.12.11</dse.scala.version>
+        <dse.scala.binary.version>2.12</dse.scala.binary.version>
         <dse.scala-tools.version>2.15.2</dse.scala-tools.version>
         <dse.maven-core.version>3.3.9</dse.maven-core.version>
-        <dse.spark.version>2.1.1</dse.spark.version>
     </properties>
 
     <build>
@@ -103,10 +102,10 @@
                             <classpathScope>compile</classpathScope>
                             <executableDependency>
                                 <groupId>com.thesamet.scalapb</groupId>
-                                <artifactId>scalapbc_2.11</artifactId>
+                                <artifactId>scalapbc_2.12</artifactId>
                             </executableDependency>
                             <arguments>
-                                <argument>-v380</argument> <!-- for protoc v3.8.0, can be 261 for v2.6.1 -->
+                                <argument>-v3.8.0</argument> <!-- for protoc v3.8.0, can be 261 for v2.6.1 -->
                                 <argument>--throw</argument> <!-- Important: otherwise scalapbc will kill the VM -->
                                 <argument>--proto_path=${project.basedir}/src/main/protobuf</argument>
                                 <argument>--proto_path=${project.basedir}/third_party</argument>
@@ -124,25 +123,12 @@
                 <dependencies>
                     <dependency>
                         <groupId>com.thesamet.scalapb</groupId>
-                        <artifactId>scalapbc_2.11</artifactId>
+                        <artifactId>scalapbc_2.12</artifactId>
                         <version>${dse.scalapb.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
 
-            <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>${dse.scala.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -198,10 +184,10 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>4.3.1</version>
                 <configuration>
                     <scalaCompatVersion>${dse.scala.binary.version}</scalaCompatVersion>
-                    <scalaVersion>${dse.scala.version}</scalaVersion>
+                    <scalaVersion>${dse.scala.binary.version}</scalaVersion>
                 </configuration>
                 <!-- other settings-->
                 <executions>
@@ -239,7 +225,7 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_2.12</artifactId>
             <version>${dse.spark.version}</version>
             <exclusions>
                 <exclusion>
@@ -251,13 +237,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.11</artifactId>
+            <artifactId>spark-hive_2.12</artifactId>
             <version>${dse.spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_2.12</artifactId>
             <version>${dse.spark.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -276,33 +262,31 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.scalatest/scalatest_2.11 -->
-        <!-- change back to scala 2.10 version of scalatest for spark -->
-
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
-            <version>3.0.0</version>
+            <artifactId>scalatest_2.12</artifactId>
+            <version>3.0.5</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.thesamet.scalapb</groupId>
-            <artifactId>scalapb-runtime_2.11</artifactId>
+            <artifactId>scalapb-runtime_2.12</artifactId>
             <version>${dse.scalapb.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.thesamet.scalapb/scalapb-json4s -->
         <dependency>
-                <groupId>com.thesamet.scalapb</groupId>
-            <artifactId>scalapb-json4s_2.11</artifactId>
-            <version>0.10.0</version>
+            <groupId>com.thesamet.scalapb</groupId>
+            <artifactId>scalapb-json4s_2.12</artifactId>
+            <version>${dse.scalapb.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.tensorflow/spark-tensorflow-connector -->
         <dependency>
             <groupId>org.tensorflow</groupId>
-            <artifactId>spark-tensorflow-connector_2.11</artifactId>
-            <version>1.15.0</version>
+            <artifactId>spark-tensorflow-connector_2.12</artifactId>
+            <version>1.11.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
+++ b/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
@@ -114,7 +114,7 @@ class FeatureStatsGeneratorTest extends StatsGeneratorTestBase {
 
     val sc = spark.sparkContext
     var arr = Seq[String]("2021-03-21T13:38:27-0701", "2020-03-21T13:38:27-0701")
-    var df = sc.parallelize(arr).toDF("TestFeatureDate").select(to_utc_timestamp($"TestFeatureDate", "utc"))
+    var df = sc.parallelize(arr).toDF("TestFeatureDate").select(to_utc_timestamp($"TestFeatureDate", "UTC"))
     var dataframes = List(NamedDataFrame(name = "testDataSet1", df))
     var dataset:DataEntrySet = generator.toDataEntries(dataframes).head
     assert(dataset.entries.head.`type`.isString === true)


### PR DESCRIPTION
   *   Spark 3 requires Scala 2.12, we have to few dependency upgrade as well, in particular,
       scala-maven-plugin, scalatest, spark-tensorflow-connector and scalapb
   *   scala-maven-plugin version 4.3.1 works, but higher version such as 4.4.x, 4.5.x do not work.
       If you use version 4.4.x, 4.5.x, you will get error identical to the one reported in :
       http://5.9.10.113/66489291/project-build-with-circle-ci-is-failing
   *   with change to scalapb to the current version, the protobuf version argument is changed.
       in scalapb 0.9.8 if the protobuf version is 3.8.0 then the argument is v380 and v261 for version 2.6.1
       in scalapb 0.11.0 we need to specify v3.8.0 for version 3.8.0
   *   spark-tensorflow-connector has no scala 2.12 releases at the moment, although the master branch does
       has code for scala 2.12. Instead of waiting for the official release, we temporarily build the dependency ourselves.
       We add git submodule of tensorflow/ecosystem, then build the dependency locally
       ```
           cd ecosystem/spark/spark-tensorflow-connector;
           mvn clean install
       ```
   *   change scalatest dependency to version 3.0.5.
       when change the scalatest to the later versions > "3.0.5", the tests will show errors like ```"object FunSuite is not a member of package org.scalatest"```