### PR TITLE
0.5.1  better handling data type exception 

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ notice here that DatasetFeatureStatisticsList is class generated based on protob
 
 ## API Usage Notes. 
 
+#### pay attention to categorical features
  API FeatureStatsGenerator.protoFromDataFrames() takes three arguments
  * dataFrames -- List of NameDataFrames
  * features -- white list of features 
@@ -532,6 +533,36 @@ notice here that DatasetFeatureStatisticsList is class generated based on protob
  depending on the data size, this can be very large. For data size with  1-2 millions rows, the result can be several 
  hundreds MB if you have more than one such features. The UI mearly use these to show raw data, so set 
  catHistgmLevel = Some(20) should be enough. This can significant reduce the result file size.
+
+
+#### pay attention to data types
+ * The library takes the data types of the feature from DataFrame schema. If the schema is derived bu Spark from the data
+   the schema may not accurate, the numerical data or integer data may become String type. especially the data frame is 
+   generated from SQL.
+
+```
+ val df = spark.sql("select * from mytable")
+```
+ in many cases, it is necessary to explicit set the data type in SQL, such as
+
+ ```
+ select 
+      field1 
+    , cast (field2 as double) as field2
+    , cast (field3 as Int) as field3
+    from mytable
+    
+ ```
+  * boolean data type needs to be converted to integer type 
+
+   ```
+      select case when booleanfield = true then 1 else 0 end as booleanfield
+      from mytable 
+   ```
+
+ * Date/Datetime data type
+   The facets-overview doesn't handle Date/Datatime data type, therefore, 
+   one needs to cast date/datatime to categorical data type before pass the data to facets-overview     
 
 ## Apache Spark 3 support and branches
 

--- a/README.md
+++ b/README.md
@@ -536,9 +536,8 @@ notice here that DatasetFeatureStatisticsList is class generated based on protob
 
 
 #### pay attention to data types
- * The library takes the data types of the feature from DataFrame schema. If the schema is derived bu Spark from the data
-   the schema may not accurate, the numerical data or integer data may become String type. especially the data frame is 
-   generated from SQL.
+ * The library takes the data types of the feature from DataFrame schema. If Spark derives the schema from the data using Spark SQL,
+   the schema may not accurate, the numerical data or integer data may become as other types depending on the data,
 
 ```
  val df = spark.sql("select * from mytable")

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,24 @@
 ## change Log, latest version on top
 
+0.5.1  better handling data type exception & dependency version conflicts
+   *   shade com.google.protobuf.* 
+       according https://scalapb.github.io/docs/sparksql/
+       "Spark ships with an old version of Google's Protocol Buffers runtime that is not 
+        compatible with the current version. Therefore, we need to shade our copy of the 
+        Protocol Buffer runtime."
+   *   "Spark 3 also ships with an incompatible version of scala-collection-compat.", 
+       although our unit test show passes, without any changes, but we experienced exceptions 
+       when trying to convert protobuf to json using json4s. Even trying to shade scala-collection-compat
+       doesn't help. here we did not shade the scala-collection-compact 
+   *   instead of directly cast categorical data type to string, 
+       the logic is changed to check the data type first before extract the value. 
+       Also catch the unexpected exception to associate the feature with exception. 
+       Many cases, where spark considered the data is string, if it is no explicitly cast to decimals. 
+       this will help debugging which feature is the issue. 
+   *   update readme     
+       
+   
+
 0.5.0  update the dependency to support Spark 3.0.1 
    *   Spark 3 requires Scala 2.12, we have to few dependency upgrade as well, in particular,
        scala-maven-plugin, scalatest, spark-tensorflow-connector and scalapb

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>facets-overview-spark</groupId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <artifactId>facets-overview-spark</artifactId>
     <name>facets-overview-spark</name>
     <organization>
@@ -156,6 +156,12 @@
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>shaded.com.google.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/test/scala/features/stats/ProtoUtilsTest.scala
+++ b/src/test/scala/features/stats/ProtoUtilsTest.scala
@@ -1,9 +1,10 @@
 package features.stats
 
 import java.io.File
-
 import features.stats.spark.{NamedDataFrame, StatsGeneratorTestBase}
 import org.apache.spark.sql.DataFrame
+
+import java.nio.file.{Files, Path}
 
 class ProtoUtilsTest extends StatsGeneratorTestBase{
   import spark.implicits._
@@ -14,11 +15,11 @@ class ProtoUtilsTest extends StatsGeneratorTestBase{
     val dataFrames = List(NamedDataFrame(name = "testDataSet", df))
     val p = generator.protoFromDataFrames(dataFrames, catHistgmLevel = Some(2))
 
-    val protoFile = new File("target", "test_proto.pb")
-    val path = ProtoUtils.persistProto(p, base64Encode = false, protoFile)
+    val protoFile : Path = Files.createTempFile("test", "pb")
+    val path = ProtoUtils.persistProto(p, base64Encode = false, protoFile.toFile)
     assert(path.toFile.exists())
-    assert(path.toFile === protoFile)
-    assert(protoFile.exists())
+    assert(path === protoFile)
+    assert(protoFile.toFile.exists())
   }
 
 }

--- a/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
+++ b/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
@@ -16,10 +16,10 @@
 
 package features.stats.spark
 import featureStatistics.feature_statistics.FeatureNameStatistics.{Type => ProtoDataType}
-import java.io.File
-import java.nio.file.{Files, Paths}
-import java.time.temporal.ChronoUnit
 
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+import java.time.temporal.ChronoUnit
 import featureStatistics.feature_statistics.{DatasetFeatureStatisticsList, FeatureNameStatistics}
 import featureStatistics.feature_statistics.Histogram.HistogramType.QUANTILES
 import features.stats.ProtoUtils
@@ -278,8 +278,9 @@ class FeatureStatsGeneratorTest extends StatsGeneratorTestBase {
         assert(strStats.unique == 10)
       }
     }
-    val protoFile = new File("target", "str_test_stats.pb")
-    val path = ProtoUtils.persistProto(proto, base64Encode = false, protoFile)
+
+    val protoFile : Path = Files.createTempFile("test", "pb")
+    val path = ProtoUtils.persistProto(proto, base64Encode = false, protoFile.toFile)
     val json = ProtoUtils.toJson(proto)
     assert(json.nonEmpty)
   }

--- a/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
+++ b/src/test/scala/features/stats/spark/FeatureStatsGeneratorTest.scala
@@ -278,9 +278,9 @@ class FeatureStatsGeneratorTest extends StatsGeneratorTestBase {
         assert(strStats.unique == 10)
       }
     }
-//    val protoFile = new File("target", "str_test_stats.pb")
-//    val path = ProtoUtils.persistProto(proto, base64Encode = false, protoFile)
-//    val json = ProtoUtils.toJson(proto)
-
+    val protoFile = new File("target", "str_test_stats.pb")
+    val path = ProtoUtils.persistProto(proto, base64Encode = false, protoFile)
+    val json = ProtoUtils.toJson(proto)
+    assert(json.nonEmpty)
   }
 }


### PR DESCRIPTION
…icts

   *   shade com.google.protobuf.*
       according https://scalapb.github.io/docs/sparksql/
       "Spark ships with an old version of Google's Protocol Buffers runtime that is not
        compatible with the current version. Therefore, we need to shade our copy of the
        Protocol Buffer runtime."
   *   "Spark 3 also ships with an incompatible version of scala-collection-compat.",
       although our unit test show passes, without any changes, but we experienced exceptions
       when trying to convert protobuf to json using json4s. Even trying to shade scala-collection-compat
       doesn't help. here we did not shade the scala-collection-compact
   *   instead of directly cast categorical data type to string,
       the logic is changed to check the data type first before extract the value.
       Also catch the unexpected exception to associate the feature with exception.
       Many cases, where spark considered the data is string, if it is no explicitly cast to decimals.
       this will help debugging which feature is the issue.
   *   update readme