### PR TITLE
filter out empty dataframe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
-## change Log, latest version on top
+## change Log, most recent version on top
+
+0.5.2  skip empty DataFrame when generating statistics
 
 0.5.1  better handling data type exception & dependency version conflicts
    *   shade com.google.protobuf.* 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>facets-overview-spark</groupId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <artifactId>facets-overview-spark</artifactId>
     <name>facets-overview-spark</name>
     <organization>

--- a/src/main/scala/features/stats/spark/FeatureStatsGenerator.scala
+++ b/src/main/scala/features/stats/spark/FeatureStatsGenerator.scala
@@ -251,7 +251,9 @@ class FeatureStatsGenerator(datasetProto: DatasetFeatureStatisticsList) {
 
     val allDatasets = datasetProto
 
-    val dfsList : List[DatasetFeatureStatistics]= datasets.zipWithIndex.map { a =>
+    val filteredDatasets = datasets.filter(ds => ds.size > 0)
+
+    val dfsList : List[DatasetFeatureStatistics]= filteredDatasets.zipWithIndex.map { a =>
       val (ds, dsIndex) = a
 
       def includeFeature(feature:String) : Boolean =


### PR DESCRIPTION
In some cases,  for example, training and test data split, we might get empty test data frame, which will cause unexpected exceptions when calculating other statistics.  In case like this, we will simply filter them out. 